### PR TITLE
fix: update set_identifier logic in Route 53 geoproximity record

### DIFF
--- a/record.tf
+++ b/record.tf
@@ -50,7 +50,7 @@ resource "aws_route53_record" "geoproximity" {
     }
   }
 
-  set_identifier = each.value.geoproximity != null ? each.value.key : null
+  set_identifier = each.value.value
 }
 
 resource "aws_route53_record" "cloudfront" {


### PR DESCRIPTION
# 🚀 update set_identifier logic in Route 53 geoproximity record
---

### 🚀 **Context**
The `set_identifier` needs to be unique for all geo prox records

---

### 🛠️ **Description**
The terraform code used the same value for `set_identifier` across the geo prox records. This pr makes sure to use unique values pr record. 

---

### ✨ **Changes in the Codebase**
- [fix: update set_identifier logic in Route 53 geoproximity record](https://github.com/pippiio/aws-dns/commit/ae9156f7e8b296f98f3607a7f4d044033a1af8d8)
  - makes sure that a unique identifier is used